### PR TITLE
Bump certifi to 2022.12.7 due to security vuln

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ attrs==22.1.0
 black==22.10.0
 bleach==5.0.1
 build==0.9.0
-certifi==2022.9.24
+certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==2.1.1
 click==8.1.3


### PR DESCRIPTION
/cc https://github.com/octodns/octodns-ddns/security/dependabot/2