### PR TITLE
script/cibuild-setup-py: install all dev requirements for testing

### DIFF
--- a/script/cibuild-setup-py
+++ b/script/cibuild-setup-py
@@ -18,6 +18,6 @@ python -m build --sdist --wheel
 echo "## validate wheel install ###################################################"
 pip install dist/*$VERSION*.whl
 echo "## validate tests can run against installed code ###############################"
-pip install pytest pytest-network
+pip install -r requirements-dev.txt
 pytest --disable-network
 echo "## complete ####################################################################"

--- a/script/cibuild-setup-py
+++ b/script/cibuild-setup-py
@@ -18,6 +18,10 @@ python -m build --sdist --wheel
 echo "## validate wheel install ###################################################"
 pip install dist/*$VERSION*.whl
 echo "## validate tests can run against installed code ###############################"
-pip install -r requirements-dev.txt
+# filename needs to resolved independently as pip requires quoting and doesn't support
+# wildcards when installing extra requirements
+# (see: https://pip.pypa.io/en/stable/user_guide/#installing-from-wheels)
+wheel_file=$(ls dist/*$VERSION*.whl)
+pip install "${wheel_file}[test]"
 pytest --disable-network
 echo "## complete ####################################################################"


### PR DESCRIPTION
install all requirements stored in requirements-dev instead of only a short hardcoded list for the test of the test after build