### PR TITLE
Bump python_requires to >=3.10, Python 3.9 is EOL

### DIFF
--- a/.changelog/b44d995a67744fed9e54e4054b1ab5e1.md
+++ b/.changelog/b44d995a67744fed9e54e4054b1ab5e1.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Bump python_requires to >=3.10, Python 3.9 is EOL

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     long_description_content_type='text/markdown',
     name='{MODULE_DASHED}',
     packages=find_packages(),
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     tests_require=tests_require,
     url='https://github.com/octodns/{MODULE_DASHED}',
     version=version(),


### PR DESCRIPTION
I was just getting around to some maintenance on my own modules and thought I would make this small contribution.